### PR TITLE
Use `home-assistant` hostname instead of hardcoded IP

### DIFF
--- a/autossh/config.yaml
+++ b/autossh/config.yaml
@@ -22,7 +22,7 @@ options:
   ssh_port: 22
   username: autossh
   remote_forwarding:
-    - '127.0.0.1:8123:172.30.32.1:8123'
+    - 'localhost:8123:home-assistant:8123'
   other_ssh_options: '-v -N'
   force_keygen: false
 schema:


### PR DESCRIPTION
Addresses https://github.com/ThomDietrich/home-assistant-addons/issues/14.

I've also changed the remote endpoint to use `localhost` which is dual-stack rather than hardcoding to IPv4-only `127.0.0.1`.